### PR TITLE
Refactor getUserAgent method and improve logging

### DIFF
--- a/OpenPanelSDK/src/main/java/com/dev/openpanelsdk/OpenPanel.kt
+++ b/OpenPanelSDK/src/main/java/com/dev/openpanelsdk/OpenPanel.kt
@@ -53,23 +53,20 @@ class OpenPanel(private val context: Context, private val options: Options) {
         }
     }
 
-    private fun getUserAgent(): String {
-        return try {
-            WebView(context).settings.userAgentString
-                ?: (System.getProperty("http.agent")?.toString() ?: "")
-        }catch (_:Exception){
-            ""
-        }
-    }
+    private fun getUserAgent(): String? = runCatching {
+        WebView(context).settings.userAgentString
+    }.getOrNull() ?: runCatching {
+        System.getProperty("http.agent")
+    }.getOrNull()
 
 
     init {
         val defaultHeaders = mutableMapOf(
             "openpanel-client-id" to options.clientId,
             "openpanel-sdk-name" to "kotlin",
-            "openpanel-sdk-version" to sdkVersion,
-            "user-agent" to getUserAgent()
+            "openpanel-sdk-version" to sdkVersion
         )
+        getUserAgent()?.let { defaultHeaders["user-agent"] = it }
         // Fetch system information
         mSystemInformation = SystemInformation.getInstance(context)
 
@@ -157,7 +154,8 @@ class OpenPanel(private val context: Context, private val options: Options) {
         flush()
 
         val mergedTraits = (globalProperties.toMap() + (traits ?: emptyMap())).toMutableMap()
-        send(IdentifyPayload(
+        send(
+            IdentifyPayload(
             profileId = profileId,
             firstName = mergedTraits["firstName"] as? String,
             lastName = mergedTraits["lastName"] as? String,
@@ -199,15 +197,15 @@ class OpenPanel(private val context: Context, private val options: Options) {
 
     private fun getDefaultEventProperties(): Map<String, Any> {
         val ret = mutableMapOf<String, Any>()
-        
+
         ret["__osVersion"] = Build.VERSION.RELEASE
         ret["__brand"] = Build.BRAND
         ret["__model"] = Build.MODEL
 
         val displayMetrics = mSystemInformation?.displayMetrics
-        ret["__screenDpi"] = displayMetrics?.densityDpi ?: null
-        ret["__screenHeight"] = displayMetrics?.heightPixels ?: null
-        ret["__screenWidth"] = displayMetrics?.widthPixels ?: null
+        displayMetrics?.densityDpi?.let { ret["__screenDpi"] = it }
+        displayMetrics?.heightPixels?.let { ret["__screenHeight"] = it }
+        displayMetrics?.widthPixels?.let { ret["__screenWidth"] = it }
 
         val applicationVersionName = mSystemInformation?.appVersionName
         if (applicationVersionName != null) {
@@ -383,7 +381,7 @@ class Api(private val config: Config) {
 
     private fun logVerbose(message: String) {
         if (config.verbose) {
-            Log.d("OpenPanel","OpenPanel: $message")
+            Log.d("OpenPanel", "OpenPanel: $message")
         }
     }
 
@@ -418,7 +416,7 @@ class Api(private val config: Config) {
 
                     connection.doOutput = true
                     connection.outputStream.use { it.write(data.toString().toByteArray()) }
-                    logVerbose("Sending data: ${data.toString()}")
+                    logVerbose("Sending data: $data")
 
                     val responseCode = connection.responseCode
                     logVerbose("Response code: $responseCode")


### PR DESCRIPTION
On some devices WebView(context).settings.userAgentString can throw NullPointerException, preventing for fallback to System.getProperty("http.agent"). With this, if webview fails, system property will be fetched. If system property fetch fails too then no user-agent header will be added, letting system to decide

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added verbose logging option to configuration for enhanced debugging capabilities.
  * Introduced new environment detection API method.

* **Improvements**
  * Refined header initialization flow for improved reliability.
  * Enhanced system information handling for better consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->